### PR TITLE
ebusd 25.1

### DIFF
--- a/ebusd/CHANGELOG.md
+++ b/ebusd/CHANGELOG.md
@@ -1,5 +1,12 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 1.1.0
+
+- Update ebusd from 23.3 to [25.1 Yuzu](https://github.com/john30/ebusd/releases/tag/25.1)
+
+### BREAKING CHANGE
+ebusd 24.1 introduced [breaking change](https://github.com/john30/ebusd/blob/master/ChangeLog.md#241-2024-10-27) for Home Assistant users. New configs result in changing unique IDs of all entities.
+
 ## 1.0.0
 
 - Initial release

--- a/ebusd/build.yaml
+++ b/ebusd/build.yaml
@@ -1,9 +1,9 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
 build_from:
-  aarch64: "john30/ebusd:v23.3"
-  amd64: "john30/ebusd:v23.3"
-  armv7: "john30/ebusd:v23.3"
-  i386: "john30/ebusd:v23.3"
+  aarch64: "john30/ebusd:v25.1"
+  amd64: "john30/ebusd:v25.1"
+  armv7: "john30/ebusd:v25.1"
+  i386: "john30/ebusd:v25.1"
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: ebusd add-on"
   org.opencontainers.image.description: "ebusd add-on"

--- a/ebusd/build.yaml
+++ b/ebusd/build.yaml
@@ -10,5 +10,5 @@ labels:
   org.opencontainers.image.source: "https://github.com/piotrtobolski/ha-addons"
   org.opencontainers.image.licenses: "Apache License 2.0"
 args:
-  BASHIO_VERSION: 0.16.2
-  TEMPIO_VERSION: 2021.09.0
+  BASHIO_VERSION: 0.17.5
+  TEMPIO_VERSION: 2024.11.2

--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -1,5 +1,5 @@
 name: "ebusd add-on"
-version: "1.0.0"
+version: "1.1.0"
 slug: "ebusd"
 description: >
   This add-on runs ebusd, a daemon for handling communication with eBUS devices

--- a/ebusd2/CHANGELOG.md
+++ b/ebusd2/CHANGELOG.md
@@ -1,5 +1,12 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 1.1.0
+
+- Update ebusd from 23.3 to [25.1 Yuzu](https://github.com/john30/ebusd/releases/tag/25.1)
+
+### BREAKING CHANGE
+ebusd 24.1 introduced [breaking change](https://github.com/john30/ebusd/blob/master/ChangeLog.md#241-2024-10-27) for Home Assistant users. New configs result in changing unique IDs of all entities.
+
 ## 1.0.0
 
 - Initial release

--- a/ebusd2/config.yaml
+++ b/ebusd2/config.yaml
@@ -1,5 +1,5 @@
 name: "ebusd add-on (2)"
-version: "1.0.0"
+version: "1.1.0"
 slug: "ebusd2"
 description: "Same as ebusd add-on but allow creating second instance of ebusd on a single HA machine."
 url: "https://github.com/piotrtobolski/ha-addons/tree/main/ebusd2"


### PR DESCRIPTION
## Changes
- Update ebusd from 23.3 to [25.1 Yuzu](https://github.com/john30/ebusd/releases/tag/25.1)

### BREAKING CHANGE
ebusd 24.1 introduced [breaking change](https://github.com/john30/ebusd/blob/master/ChangeLog.md#241-2024-10-27) for Home Assistant users. New configs result in changing unique IDs of all entities.