### PR TITLE
Deprecate ebusd addons in favor of micro-ebusd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Piotr Tobolski Home Assistant add-on repository
 
+> **Deprecated:** These add-ons are deprecated. Consider using [micro-ebusd](https://token.ebusd.eu) instead, which runs directly on eBUS Adapter hardware and integrates with Home Assistant via MQTT Discovery — no separate daemon or add-on needed.
+
 [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fpiotrtobolski%2Fha-addons)
 
 ## Add-ons

--- a/ebusd/CHANGELOG.md
+++ b/ebusd/CHANGELOG.md
@@ -1,5 +1,9 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 1.2.0
+
+- Deprecated: This add-on is deprecated. Consider using [micro-ebusd](https://token.ebusd.eu) instead.
+
 ## 1.1.0
 
 - Update ebusd from 23.3 to [25.1 Yuzu](https://github.com/john30/ebusd/releases/tag/25.1)

--- a/ebusd/DOCS.md
+++ b/ebusd/DOCS.md
@@ -1,5 +1,7 @@
 # Home Assistant Add-on: eBUSd
 
+> **Deprecated:** This add-on is deprecated. Consider using [micro-ebusd](https://token.ebusd.eu) instead, which runs directly on eBUS Adapter hardware and integrates with Home Assistant via MQTT Discovery — no separate daemon or add-on needed.
+
 This is to run [ebusd](http://ebusd.eu) as supervisor addon (docker container) in Home Assistant OS.
 
 ## How to run ebusd

--- a/ebusd/README.md
+++ b/ebusd/README.md
@@ -1,5 +1,7 @@
 # Home Assistant Add-on: ebusd
 
+> **Deprecated:** This add-on is deprecated. Consider using [micro-ebusd](https://token.ebusd.eu) instead, which runs directly on eBUS Adapter hardware and integrates with Home Assistant via MQTT Discovery — no separate daemon or add-on needed.
+
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
 ![Supports armhf Architecture][armhf-shield]

--- a/ebusd/config.yaml
+++ b/ebusd/config.yaml
@@ -1,6 +1,7 @@
 name: "ebusd add-on"
-version: "1.1.0"
+version: "1.2.0"
 slug: "ebusd"
+stage: deprecated
 description: >
   This add-on runs ebusd, a daemon for handling communication with eBUS devices
   connected to a 2-wire bus system (“energy bus” used by numerous heating systems)

--- a/ebusd2/CHANGELOG.md
+++ b/ebusd2/CHANGELOG.md
@@ -1,5 +1,9 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 1.2.0
+
+- Deprecated: This add-on is deprecated. Consider using [micro-ebusd](https://token.ebusd.eu) instead.
+
 ## 1.1.0
 
 - Update ebusd from 23.3 to [25.1 Yuzu](https://github.com/john30/ebusd/releases/tag/25.1)

--- a/ebusd2/README.md
+++ b/ebusd2/README.md
@@ -1,5 +1,7 @@
 # Home Assistant Add-on: ebusd2
 
+> **Deprecated:** This add-on is deprecated. Consider using [micro-ebusd](https://token.ebusd.eu) instead, which runs directly on eBUS Adapter hardware and integrates with Home Assistant via MQTT Discovery — no separate daemon or add-on needed.
+
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
 ![Supports armhf Architecture][armhf-shield]

--- a/ebusd2/config.yaml
+++ b/ebusd2/config.yaml
@@ -1,6 +1,7 @@
 name: "ebusd add-on (2)"
-version: "1.1.0"
+version: "1.2.0"
 slug: "ebusd2"
+stage: deprecated
 description: "Same as ebusd add-on but allow creating second instance of ebusd on a single HA machine."
 url: "https://github.com/piotrtobolski/ha-addons/tree/main/ebusd2"
 arch:


### PR DESCRIPTION
## Summary
- Mark both `ebusd` and `ebusd2` addons as deprecated (`stage: deprecated` in config.yaml)
- Add deprecation notices to all READMEs and DOCS pointing users to [micro-ebusd](https://github.com/john30/ebusd-addon)
- Bump addon versions from 1.1.0 to 1.2.0

## Test plan
- [ ] Verify `stage: deprecated` hides addons from the store (visible only in advanced mode)
- [ ] Verify deprecation notices render correctly
- [ ] Confirm existing addon installations continue to work